### PR TITLE
Add helpful dev tools

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,32 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main main.go"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor"]
+  exclude_file = []
+  exclude_regex = []
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  kill_delay = "0s"
+  log = "build-errors.log"
+  send_interrupt = false
+  stop_on_error = true
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,19 @@ run:
 .PHONY: test
 test:
 	go test -p 1 ./...
+
+# Run the application using cosmtrek/air for live-reloading
+.PHONY: dev
+dev:
+	docker-compose -f docker-compose.dev.yml up -d
+	make -s dev-logs
+
+# Stop the docker-compose resources
+.PHONY: dev-down
+dev-down:
+	docker-compose -f docker-compose.dev.yml down
+
+# Follow the logs for the specified docker-compose services. Additional services can be added after api if desired.
+.PHONY: dev-logs
+dev-logs:
+	docker-compose -f docker-compose.dev.yml logs -f api

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ Once that completes, you can start the application by executing `make run`. By d
 
 If you ever want to quickly drop the Docker containers and restart them in order to wipe all data, execute `make reset`.
 
+Alternatively, to automatically restart the application when changes are detected, execute `make dev` to start a Docker container with "live-reloading" enabled. Alongside this container are a few helpful services that allow for ease of development.
+
+Bring down the services by executing `make dev-down`.
+
+#### Local Services
+
+- [Live reload of Go app](https://github.com/cosmtrek/air)
+- [Redis UI](https://github.com/patrikx3/redis-ui)
+- [Postgres Admin](https://hub.docker.com/r/dpage/pgadmin4/)
+- [SMTP Server](https://github.com/maildev/maildev)
+
 ### Running tests
 
 To run all tests in the application, execute `make test`. This ensures that the tests from each package are not run in parallel. This is required since many packages contain tests that connect to the test database which is dropped and recreated automatically for each package.

--- a/container/dev.Dockerfile
+++ b/container/dev.Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.17-alpine
+
+RUN apk update && apk add --no-cache musl-dev gcc git build-base
+
+RUN go get github.com/cosmtrek/air
+
+WORKDIR /app
+
+EXPOSE 8000
+
+CMD ["air", "-c", ".air.toml"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,94 @@
+version: '3'
+services:
+  api:
+    build:
+      context: container
+      dockerfile: dev.Dockerfile
+    container_name: api
+    environment:
+      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+      - CACHE_HOSTNAME=cache
+      - DB_HOSTNAME=db
+      - MAIL_HOSTNAME=mail
+      - MAIL_PORT=25
+    volumes:
+      - ./:/app
+      - type: bind
+        source: /run/host-services/ssh-auth.sock
+        target: /run/host-services/ssh-auth.sock
+    restart: unless-stopped
+    ports:
+      - '8000:8000'
+    links:
+      - cache
+      - db
+      - mail
+    networks:
+      pagoda-network:
+        ipv4_address: 172.10.0.2
+  
+  cache:
+    image: 'redis:alpine'
+    ports:
+      - '6379:6379'
+    networks:
+      pagoda-network:
+        ipv4_address: 172.10.0.3
+  
+  cache-ui:
+    image: patrikx3/p3x-redis-ui:latest
+    ports:
+      - '7843:7843'
+    volumes:
+      - tmp:/settings
+    links:
+      - cache
+    networks:
+      pagoda-network:
+        ipv4_address: 172.10.0.4
+
+  db:
+    image: postgres:alpine
+    ports:
+      - '5432:5432'
+    environment:
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=admin
+      - POSTGRES_DB=app
+    networks:
+      pagoda-network:
+        ipv4_address: 172.10.0.5
+  
+  db-admin:
+    image: dpage/pgadmin4
+    container_name: db-admin
+    restart: unless-stopped
+    ports:
+      - '5433:80'
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=admin@local.com
+      - PGADMIN_DEFAULT_PASSWORD=admin
+    links:
+      - db
+    networks:
+      pagoda-network:
+        ipv4_address: 172.10.0.6
+  
+  mail:
+    image: maildev/maildev
+    ports:
+      - '1080:80'
+    networks:
+      pagoda-network:
+        ipv4_address: 172.10.0.7
+
+networks:
+  pagoda-network:
+    name: 'pagoda-network'
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.10.0.0/16
+
+volumes:
+  tmp:


### PR DESCRIPTION
## Proposed Changes

These are tools that I find extremely helpful when developing locally, especially when external dependencies (databases, caches, etc.) are involved.

- Add "Live reloading" of the Go application via https://github.com/cosmtrek/air
- Add a Redis UI via https://github.com/patrikx3/redis-ui
- Add a Postgres UI via https://hub.docker.com/r/dpage/pgadmin4/
- Add an SMTP server via https://github.com/maildev/maildev
- Add `docker-compose.dev.yml` to coordinate all new services
- Add `dev`, `dev-down`, `dev-logs` Makefile targets
- Update the README with brief instructions on how to use the new Makefile targets
- Ignore the `tmp` directory (created by "Live Reloading" and the Redis UI) via `.gitignore`