### PR TITLE
Prevent caching pages if user is authenticated

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -108,7 +108,7 @@ func (c *Controller) RenderPage(ctx echo.Context, page Page) error {
 
 // cachePage caches the HTML for a given Page if the Page has caching enabled
 func (c *Controller) cachePage(ctx echo.Context, page Page, html *bytes.Buffer) {
-	if !page.Cache.Enabled {
+	if !page.Cache.Enabled || page.IsAuth {
 		return
 	}
 


### PR DESCRIPTION
In the example the about page is cached even as authenticated user. After logout this cached page is returned to every request for the about page. The menu column in the about page is still showing the logout button. This PR prevents the caching of pages for authenticated users.