### PR TITLE
fix pass []any as any by asasalint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+coverage.out
+.vscode

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -152,7 +152,7 @@ func (c *Controller) cachePage(ctx echo.Context, page Page, html *bytes.Buffer) 
 
 // Redirect redirects to a given route name with optional route parameters
 func (c *Controller) Redirect(ctx echo.Context, route string, routeParams ...interface{}) error {
-	url := ctx.Echo().Reverse(route, routeParams)
+	url := ctx.Echo().Reverse(route, routeParams...)
 
 	if htmx.GetRequest(ctx).Boosted {
 		htmx.Response{

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -51,6 +51,15 @@ func TestController_Redirect(t *testing.T) {
 	assert.Equal(t, http.StatusFound, ctx.Response().Status)
 }
 
+func TestController_Redirect_Params(t *testing.T) {
+	ctx, _ := tests.NewContext(c.Web, "/abc")
+	ctr := NewController(c)
+	err := ctr.Redirect(ctx, "/params/:foo/bar/:qux", "one", "two")
+	require.NoError(t, err)
+	assert.Equal(t, "/params/one/bar/two", ctx.Response().Header().Get(echo.HeaderLocation))
+	assert.Equal(t, http.StatusFound, ctx.Response().Status)
+}
+
 func TestController_RenderPage(t *testing.T) {
 	setup := func() (echo.Context, *httptest.ResponseRecorder, Controller, Page) {
 		ctx, rec := tests.NewContext(c.Web, "/test/TestController_RenderPage")


### PR DESCRIPTION
i'm write a [linter](https://github.com/alingse/asasalint) about check pass `[]any` as `any` in variadic functions

I check the top golang web repo, and found this.

