### PR TITLE
Update Test Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.19
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.cache/go-build


### PR DESCRIPTION
This PR updates to the actions used in the Test Workflow from `v2` to `v3` since the `v2` actions have deprecation warnings.

![image](https://user-images.githubusercontent.com/1667251/213077733-34f1591b-53b0-436b-a9f3-3bda637f32f3.png)
