### PR TITLE
Bind DB and Redis to 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     image: "redis:alpine"
     container_name: pagoda_cache
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
   db:
     image: postgres:alpine
     container_name: pagoda_db
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=admin


### PR DESCRIPTION
I recently learned it is an insecure practice to bind to ports without specifying the host as 127.0.0.1 here https://earthly.dev/blog/youre-using-docker-compose-wrong/ (problem 2)