### PR TITLE
fix flakey context test

### DIFF
--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -15,8 +15,13 @@ func TestIsCanceled(t *testing.T) {
 	cancel()
 	assert.True(t, IsCanceledError(ctx.Err()))
 
-	ctx, cancel = context.WithTimeout(context.Background(), time.Microsecond)
-	time.Sleep(time.Microsecond * 5)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Microsecond*5)
+	doneCh := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		doneCh <- struct{}{}
+	}()
+	<-doneCh
 	cancel()
 	assert.False(t, IsCanceledError(ctx.Err()))
 


### PR DESCRIPTION
On my machine (and possibly GH Actions) the test seemed to sometimes fail due to the timeout, not actually as a result of the context being cancelled without an error. We use a channel so we're actually testing the context's state.