### PR TITLE
Add live-reload for go files

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,33 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main cmd/web/main.go"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor"]
+  exclude_file = []
+  exclude_regex = []
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html", ".env"]
+  kill_delay = "0s"
+  log = "build-errors.log"
+  send_interrupt = false
+  stop_on_error = true
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  time = false
+
+[misc]
+  clean_on_exit = false
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ db-test:
 cache:
 	docker exec -it pagoda_cache redis-cli
 
- # Connect to the test cache
+# Connect to the test cache
 .PHONY: cache-test
 cache-test:
 	docker exec -it pagoda_cache redis-cli -n 1
@@ -43,10 +43,20 @@ up:
 	$(DCO_BIN) up -d
 	sleep 3
 
+.PHONY: dev-up
+dev-up:
+	$(DCO_BIN) -f docker-compose.dev.yml up
+	sleep 3
+
 # Rebuild Docker containers to wipe all data
 .PHONY: reset
 reset:
 	$(DCO_BIN) down
+	make up
+
+.PHONY: dev-reset
+dev-reset:
+	$(DCO_BIN) -f docker-compose.dev.yml down
 	make up
 
 # Run the application

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.19-alpine
+
+RUN apk update && apk add --no-cache musl-dev gcc git build-base
+
+RUN go install github.com/cosmtrek/air@latest
+
+WORKDIR /app
+
+EXPOSE 8080
+
+CMD ["air", "-c", ".air.toml"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,35 @@
+version: '3'
+
+services:
+  dev_web:
+    build:
+      context: ${PWD}
+      dockerfile: dev.Dockerfile
+    container_name: dev_web
+    environment:
+      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+      - PAGODA_CACHE_HOSTNAME=dev_cache
+      - PAGODA_DATABASE_HOSTNAME=dev_db
+    volumes:
+    - ${PWD}/:/app
+    - type: bind
+      source: /run/host-services/ssh-auth.sock
+      target: /run/host-services/ssh-auth.sock
+    restart: unless-stopped
+    ports:
+    - "8000:8000"
+  dev_cache:
+    image: "redis:alpine"
+    container_name: dev_pagoda_cache
+    ports:
+      - "127.0.0.1:6379:6379"
+  dev_db:
+    # PG 16 is currenly not supported https://github.com/ent/ent/issues/3750
+    image: postgres:15-alpine
+    container_name: dev_pagoda_db
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=admin
+      - POSTGRES_DB=app


### PR DESCRIPTION
This is a minimization of the changes from https://github.com/mikestefanello/pagoda/pull/2. I've used this template for quite a few other projects and these changes are always the first update I make to the project, so I figured others may find them useful as well.

The main change here is the live-reloading of any changed `.go` files, triggering the auto rebuild and rerun of the `web` app running in docker compose. This is achieved via https://github.com/cosmtrek/air.

![pagoda_local-dev-tools](https://github.com/mikestefanello/pagoda/assets/10732563/fd52a2ad-6098-4e82-8f14-786f0a4934b1)
