### PR TITLE
HX-Push has been depreacted in favour of HX-Push-Url

### DIFF
--- a/pkg/htmx/htmx.go
+++ b/pkg/htmx/htmx.go
@@ -6,7 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-//  Headers (https://htmx.org/docs/#requests)
+// Headers (https://htmx.org/reference/#headers)
 const (
 	HeaderRequest            = "HX-Request"
 	HeaderBoosted            = "HX-Boosted"
@@ -16,7 +16,7 @@ const (
 	HeaderTriggerAfterSettle = "HX-Trigger-After-Settle"
 	HeaderTarget             = "HX-Target"
 	HeaderPrompt             = "HX-Prompt"
-	HeaderPush               = "HX-Push"
+	HeaderPushURL            = "HX-Push-Url"
 	HeaderRedirect           = "HX-Redirect"
 	HeaderRefresh            = "HX-Refresh"
 )
@@ -59,7 +59,7 @@ func GetRequest(ctx echo.Context) Request {
 // Apply applies data from a Response to a server response
 func (r Response) Apply(ctx echo.Context) {
 	if r.Push != "" {
-		ctx.Response().Header().Set(HeaderPush, r.Push)
+		ctx.Response().Header().Set(HeaderPushURL, r.Push)
 	}
 	if r.Redirect != "" {
 		ctx.Response().Header().Set(HeaderRedirect, r.Redirect)

--- a/pkg/htmx/htmx_test.go
+++ b/pkg/htmx/htmx_test.go
@@ -42,7 +42,7 @@ func TestResponse_Apply(t *testing.T) {
 	}
 	r.Apply(ctx)
 
-	assert.Equal(t, "a", ctx.Response().Header().Get(HeaderPush))
+	assert.Equal(t, "a", ctx.Response().Header().Get(HeaderPushURL))
 	assert.Equal(t, "b", ctx.Response().Header().Get(HeaderRedirect))
 	assert.Equal(t, "true", ctx.Response().Header().Get(HeaderRefresh))
 	assert.Equal(t, "c", ctx.Response().Header().Get(HeaderTrigger))


### PR DESCRIPTION
Hi there,

Noticed that `HX-Push` is [deprected](https://htmx.org/headers/hx-push/) in favour of `HX-Push-Url`.