### PR TITLE
Use alpine v3 `click.outside` event name

### DIFF
--- a/templates/layouts/main.gohtml
+++ b/templates/layouts/main.gohtml
@@ -67,7 +67,7 @@
         <input class="input" type="search" placeholder="Search..." @click="modal = true; $nextTick(() => $refs.input.focus());"/>
         <div class="modal" :class="modal ? 'is-active' : ''" x-show="modal == true">
             <div class="modal-background"></div>
-            <div class="modal-content" @click.away="modal = false;">
+            <div class="modal-content" @click.outside="modal = false;">
                 <div class="box">
                     <h2 class="subtitle">Search</h2>
                     <p class="control">


### PR DESCRIPTION
Alpine v3 deprecates the v2 `click.away` event and marks it for possible future removal, replacing it with `click.outside`.

See v3 release notes: https://alpinejs.dev/upgrade-guide#away-replace-with-outside