### PR TITLE
Generic User management module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,11 @@ To make things easy, the _Backlite_ client is provided as a _Service_ on the `Co
 
 Configuration for the _Backlite_ client is exposed through the app's yaml configuration. The required database schema will be automatically installed when the app starts.
 
+## User Management
+
+By default, an admin user with "test@pagoda.com" as email and "manage" as password is available to enable and disable other users. This functionality can be extended to include role assignment and role creation. However, the admin user itself cannot be disabled.
+
+The CheckUserState middleware can be used to verify a user's state (Enable or Disabled) before performing any actions.
 ### Queues
 
 A full example of a queue implementation can be found in `pkg/tasks` with an interactive form to create a task and add to the queue at `/task` (see `pkg/handlers/task.go`). Also refer to the [Backlite](https://github.com/mikestefanello/backlite) documentation for reference and examples.

--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,7 @@ type (
 			Length     int
 		}
 		EmailVerificationTokenExpiration time.Duration
+		AdminEmail                       string
 	}
 
 	// CacheConfig stores the cache configuration

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,7 @@ app:
       expiration: "60m"
       length: 64
   emailVerificationTokenExpiration: "12h"
+  adminEmail: "test@pagaoda.com"
 
 cache:
   capacity: 100000

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -36,6 +36,8 @@ var (
 		{Name: "email", Type: field.TypeString, Unique: true},
 		{Name: "password", Type: field.TypeString},
 		{Name: "verified", Type: field.TypeBool, Default: false},
+		{Name: "role", Type: field.TypeString, Default: "user"},
+		{Name: "disabled", Type: field.TypeBool, Default: false},
 		{Name: "created_at", Type: field.TypeTime},
 	}
 	// UsersTable holds the schema information for the "users" table.

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -486,6 +486,8 @@ type UserMutation struct {
 	email         *string
 	password      *string
 	verified      *bool
+	role          *string
+	disabled      *bool
 	created_at    *time.Time
 	clearedFields map[string]struct{}
 	owner         map[int]struct{}
@@ -738,6 +740,78 @@ func (m *UserMutation) ResetVerified() {
 	m.verified = nil
 }
 
+// SetRole sets the "role" field.
+func (m *UserMutation) SetRole(s string) {
+	m.role = &s
+}
+
+// Role returns the value of the "role" field in the mutation.
+func (m *UserMutation) Role() (r string, exists bool) {
+	v := m.role
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRole returns the old "role" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldRole(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRole is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRole requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRole: %w", err)
+	}
+	return oldValue.Role, nil
+}
+
+// ResetRole resets all changes to the "role" field.
+func (m *UserMutation) ResetRole() {
+	m.role = nil
+}
+
+// SetDisabled sets the "disabled" field.
+func (m *UserMutation) SetDisabled(b bool) {
+	m.disabled = &b
+}
+
+// Disabled returns the value of the "disabled" field in the mutation.
+func (m *UserMutation) Disabled() (r bool, exists bool) {
+	v := m.disabled
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDisabled returns the old "disabled" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldDisabled(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDisabled is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDisabled requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDisabled: %w", err)
+	}
+	return oldValue.Disabled, nil
+}
+
+// ResetDisabled resets all changes to the "disabled" field.
+func (m *UserMutation) ResetDisabled() {
+	m.disabled = nil
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (m *UserMutation) SetCreatedAt(t time.Time) {
 	m.created_at = &t
@@ -862,7 +936,7 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 7)
 	if m.name != nil {
 		fields = append(fields, user.FieldName)
 	}
@@ -874,6 +948,12 @@ func (m *UserMutation) Fields() []string {
 	}
 	if m.verified != nil {
 		fields = append(fields, user.FieldVerified)
+	}
+	if m.role != nil {
+		fields = append(fields, user.FieldRole)
+	}
+	if m.disabled != nil {
+		fields = append(fields, user.FieldDisabled)
 	}
 	if m.created_at != nil {
 		fields = append(fields, user.FieldCreatedAt)
@@ -894,6 +974,10 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 		return m.Password()
 	case user.FieldVerified:
 		return m.Verified()
+	case user.FieldRole:
+		return m.Role()
+	case user.FieldDisabled:
+		return m.Disabled()
 	case user.FieldCreatedAt:
 		return m.CreatedAt()
 	}
@@ -913,6 +997,10 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldPassword(ctx)
 	case user.FieldVerified:
 		return m.OldVerified(ctx)
+	case user.FieldRole:
+		return m.OldRole(ctx)
+	case user.FieldDisabled:
+		return m.OldDisabled(ctx)
 	case user.FieldCreatedAt:
 		return m.OldCreatedAt(ctx)
 	}
@@ -951,6 +1039,20 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetVerified(v)
+		return nil
+	case user.FieldRole:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRole(v)
+		return nil
+	case user.FieldDisabled:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDisabled(v)
 		return nil
 	case user.FieldCreatedAt:
 		v, ok := value.(time.Time)
@@ -1019,6 +1121,12 @@ func (m *UserMutation) ResetField(name string) error {
 		return nil
 	case user.FieldVerified:
 		m.ResetVerified()
+		return nil
+	case user.FieldRole:
+		m.ResetRole()
+		return nil
+	case user.FieldDisabled:
+		m.ResetDisabled()
 		return nil
 	case user.FieldCreatedAt:
 		m.ResetCreatedAt()

--- a/ent/passwordtoken.go
+++ b/ent/passwordtoken.go
@@ -41,12 +41,10 @@ type PasswordTokenEdges struct {
 // UserOrErr returns the User value or an error if the edge
 // was not loaded in eager-loading, or loaded but was not found.
 func (e PasswordTokenEdges) UserOrErr() (*User, error) {
-	if e.loadedTypes[0] {
-		if e.User == nil {
-			// Edge was loaded but was not found.
-			return nil, &NotFoundError{label: user.Label}
-		}
+	if e.User != nil {
 		return e.User, nil
+	} else if e.loadedTypes[0] {
+		return nil, &NotFoundError{label: user.Label}
 	}
 	return nil, &NotLoadedError{edge: "user"}
 }

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -44,13 +44,21 @@ func init() {
 	userDescVerified := userFields[3].Descriptor()
 	// user.DefaultVerified holds the default value on creation for the verified field.
 	user.DefaultVerified = userDescVerified.Default.(bool)
+	// userDescRole is the schema descriptor for role field.
+	userDescRole := userFields[4].Descriptor()
+	// user.DefaultRole holds the default value on creation for the role field.
+	user.DefaultRole = userDescRole.Default.(string)
+	// userDescDisabled is the schema descriptor for disabled field.
+	userDescDisabled := userFields[5].Descriptor()
+	// user.DefaultDisabled holds the default value on creation for the disabled field.
+	user.DefaultDisabled = userDescDisabled.Default.(bool)
 	// userDescCreatedAt is the schema descriptor for created_at field.
-	userDescCreatedAt := userFields[4].Descriptor()
+	userDescCreatedAt := userFields[6].Descriptor()
 	// user.DefaultCreatedAt holds the default value on creation for the created_at field.
 	user.DefaultCreatedAt = userDescCreatedAt.Default.(func() time.Time)
 }
 
 const (
-	Version = "v0.12.5"                                         // Version of ent codegen.
-	Sum     = "h1:KREM5E4CSoej4zeGa88Ou/gfturAnpUv0mzAjch1sj4=" // Sum of ent codegen.
+	Version = "v0.13.1"                                         // Version of ent codegen.
+	Sum     = "h1:uD8QwN1h6SNphdCCzmkMN3feSUzNnVvV/WIkHKMbzOE=" // Sum of ent codegen.
 )

--- a/ent/schema/user.go
+++ b/ent/schema/user.go
@@ -31,6 +31,10 @@ func (User) Fields() []ent.Field {
 			NotEmpty(),
 		field.Bool("verified").
 			Default(false),
+		field.String("role").
+			Default("user"),
+		field.Bool("disabled").
+			Default(false),
 		field.Time("created_at").
 			Default(time.Now).
 			Immutable(),

--- a/ent/user.go
+++ b/ent/user.go
@@ -25,6 +25,10 @@ type User struct {
 	Password string `json:"-"`
 	// Verified holds the value of the "verified" field.
 	Verified bool `json:"verified,omitempty"`
+	// Role holds the value of the "role" field.
+	Role string `json:"role,omitempty"`
+	// Disabled holds the value of the "disabled" field.
+	Disabled bool `json:"disabled,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -56,11 +60,11 @@ func (*User) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case user.FieldVerified:
+		case user.FieldVerified, user.FieldDisabled:
 			values[i] = new(sql.NullBool)
 		case user.FieldID:
 			values[i] = new(sql.NullInt64)
-		case user.FieldName, user.FieldEmail, user.FieldPassword:
+		case user.FieldName, user.FieldEmail, user.FieldPassword, user.FieldRole:
 			values[i] = new(sql.NullString)
 		case user.FieldCreatedAt:
 			values[i] = new(sql.NullTime)
@@ -108,6 +112,18 @@ func (u *User) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field verified", values[i])
 			} else if value.Valid {
 				u.Verified = value.Bool
+			}
+		case user.FieldRole:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field role", values[i])
+			} else if value.Valid {
+				u.Role = value.String
+			}
+		case user.FieldDisabled:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field disabled", values[i])
+			} else if value.Valid {
+				u.Disabled = value.Bool
 			}
 		case user.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -166,6 +182,12 @@ func (u *User) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("verified=")
 	builder.WriteString(fmt.Sprintf("%v", u.Verified))
+	builder.WriteString(", ")
+	builder.WriteString("role=")
+	builder.WriteString(u.Role)
+	builder.WriteString(", ")
+	builder.WriteString("disabled=")
+	builder.WriteString(fmt.Sprintf("%v", u.Disabled))
 	builder.WriteString(", ")
 	builder.WriteString("created_at=")
 	builder.WriteString(u.CreatedAt.Format(time.ANSIC))

--- a/ent/user/user.go
+++ b/ent/user/user.go
@@ -23,6 +23,10 @@ const (
 	FieldPassword = "password"
 	// FieldVerified holds the string denoting the verified field in the database.
 	FieldVerified = "verified"
+	// FieldRole holds the string denoting the role field in the database.
+	FieldRole = "role"
+	// FieldDisabled holds the string denoting the disabled field in the database.
+	FieldDisabled = "disabled"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
 	FieldCreatedAt = "created_at"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
@@ -45,6 +49,8 @@ var Columns = []string{
 	FieldEmail,
 	FieldPassword,
 	FieldVerified,
+	FieldRole,
+	FieldDisabled,
 	FieldCreatedAt,
 }
 
@@ -73,6 +79,10 @@ var (
 	PasswordValidator func(string) error
 	// DefaultVerified holds the default value on creation for the "verified" field.
 	DefaultVerified bool
+	// DefaultRole holds the default value on creation for the "role" field.
+	DefaultRole string
+	// DefaultDisabled holds the default value on creation for the "disabled" field.
+	DefaultDisabled bool
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 )
@@ -103,6 +113,16 @@ func ByPassword(opts ...sql.OrderTermOption) OrderOption {
 // ByVerified orders the results by the verified field.
 func ByVerified(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldVerified, opts...).ToFunc()
+}
+
+// ByRole orders the results by the role field.
+func ByRole(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRole, opts...).ToFunc()
+}
+
+// ByDisabled orders the results by the disabled field.
+func ByDisabled(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDisabled, opts...).ToFunc()
 }
 
 // ByCreatedAt orders the results by the created_at field.

--- a/ent/user/where.go
+++ b/ent/user/where.go
@@ -75,6 +75,16 @@ func Verified(v bool) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldVerified, v))
 }
 
+// Role applies equality check predicate on the "role" field. It's identical to RoleEQ.
+func Role(v string) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldRole, v))
+}
+
+// Disabled applies equality check predicate on the "disabled" field. It's identical to DisabledEQ.
+func Disabled(v bool) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldDisabled, v))
+}
+
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.
 func CreatedAt(v time.Time) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldCreatedAt, v))
@@ -283,6 +293,81 @@ func VerifiedEQ(v bool) predicate.User {
 // VerifiedNEQ applies the NEQ predicate on the "verified" field.
 func VerifiedNEQ(v bool) predicate.User {
 	return predicate.User(sql.FieldNEQ(FieldVerified, v))
+}
+
+// RoleEQ applies the EQ predicate on the "role" field.
+func RoleEQ(v string) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldRole, v))
+}
+
+// RoleNEQ applies the NEQ predicate on the "role" field.
+func RoleNEQ(v string) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldRole, v))
+}
+
+// RoleIn applies the In predicate on the "role" field.
+func RoleIn(vs ...string) predicate.User {
+	return predicate.User(sql.FieldIn(FieldRole, vs...))
+}
+
+// RoleNotIn applies the NotIn predicate on the "role" field.
+func RoleNotIn(vs ...string) predicate.User {
+	return predicate.User(sql.FieldNotIn(FieldRole, vs...))
+}
+
+// RoleGT applies the GT predicate on the "role" field.
+func RoleGT(v string) predicate.User {
+	return predicate.User(sql.FieldGT(FieldRole, v))
+}
+
+// RoleGTE applies the GTE predicate on the "role" field.
+func RoleGTE(v string) predicate.User {
+	return predicate.User(sql.FieldGTE(FieldRole, v))
+}
+
+// RoleLT applies the LT predicate on the "role" field.
+func RoleLT(v string) predicate.User {
+	return predicate.User(sql.FieldLT(FieldRole, v))
+}
+
+// RoleLTE applies the LTE predicate on the "role" field.
+func RoleLTE(v string) predicate.User {
+	return predicate.User(sql.FieldLTE(FieldRole, v))
+}
+
+// RoleContains applies the Contains predicate on the "role" field.
+func RoleContains(v string) predicate.User {
+	return predicate.User(sql.FieldContains(FieldRole, v))
+}
+
+// RoleHasPrefix applies the HasPrefix predicate on the "role" field.
+func RoleHasPrefix(v string) predicate.User {
+	return predicate.User(sql.FieldHasPrefix(FieldRole, v))
+}
+
+// RoleHasSuffix applies the HasSuffix predicate on the "role" field.
+func RoleHasSuffix(v string) predicate.User {
+	return predicate.User(sql.FieldHasSuffix(FieldRole, v))
+}
+
+// RoleEqualFold applies the EqualFold predicate on the "role" field.
+func RoleEqualFold(v string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldRole, v))
+}
+
+// RoleContainsFold applies the ContainsFold predicate on the "role" field.
+func RoleContainsFold(v string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldRole, v))
+}
+
+// DisabledEQ applies the EQ predicate on the "disabled" field.
+func DisabledEQ(v bool) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldDisabled, v))
+}
+
+// DisabledNEQ applies the NEQ predicate on the "disabled" field.
+func DisabledNEQ(v bool) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldDisabled, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.

--- a/ent/user_create.go
+++ b/ent/user_create.go
@@ -53,6 +53,34 @@ func (uc *UserCreate) SetNillableVerified(b *bool) *UserCreate {
 	return uc
 }
 
+// SetRole sets the "role" field.
+func (uc *UserCreate) SetRole(s string) *UserCreate {
+	uc.mutation.SetRole(s)
+	return uc
+}
+
+// SetNillableRole sets the "role" field if the given value is not nil.
+func (uc *UserCreate) SetNillableRole(s *string) *UserCreate {
+	if s != nil {
+		uc.SetRole(*s)
+	}
+	return uc
+}
+
+// SetDisabled sets the "disabled" field.
+func (uc *UserCreate) SetDisabled(b bool) *UserCreate {
+	uc.mutation.SetDisabled(b)
+	return uc
+}
+
+// SetNillableDisabled sets the "disabled" field if the given value is not nil.
+func (uc *UserCreate) SetNillableDisabled(b *bool) *UserCreate {
+	if b != nil {
+		uc.SetDisabled(*b)
+	}
+	return uc
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (uc *UserCreate) SetCreatedAt(t time.Time) *UserCreate {
 	uc.mutation.SetCreatedAt(t)
@@ -123,6 +151,14 @@ func (uc *UserCreate) defaults() error {
 		v := user.DefaultVerified
 		uc.mutation.SetVerified(v)
 	}
+	if _, ok := uc.mutation.Role(); !ok {
+		v := user.DefaultRole
+		uc.mutation.SetRole(v)
+	}
+	if _, ok := uc.mutation.Disabled(); !ok {
+		v := user.DefaultDisabled
+		uc.mutation.SetDisabled(v)
+	}
 	if _, ok := uc.mutation.CreatedAt(); !ok {
 		if user.DefaultCreatedAt == nil {
 			return fmt.Errorf("ent: uninitialized user.DefaultCreatedAt (forgotten import ent/runtime?)")
@@ -161,6 +197,12 @@ func (uc *UserCreate) check() error {
 	}
 	if _, ok := uc.mutation.Verified(); !ok {
 		return &ValidationError{Name: "verified", err: errors.New(`ent: missing required field "User.verified"`)}
+	}
+	if _, ok := uc.mutation.Role(); !ok {
+		return &ValidationError{Name: "role", err: errors.New(`ent: missing required field "User.role"`)}
+	}
+	if _, ok := uc.mutation.Disabled(); !ok {
+		return &ValidationError{Name: "disabled", err: errors.New(`ent: missing required field "User.disabled"`)}
 	}
 	if _, ok := uc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "User.created_at"`)}
@@ -206,6 +248,14 @@ func (uc *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	if value, ok := uc.mutation.Verified(); ok {
 		_spec.SetField(user.FieldVerified, field.TypeBool, value)
 		_node.Verified = value
+	}
+	if value, ok := uc.mutation.Role(); ok {
+		_spec.SetField(user.FieldRole, field.TypeString, value)
+		_node.Role = value
+	}
+	if value, ok := uc.mutation.Disabled(); ok {
+		_spec.SetField(user.FieldDisabled, field.TypeBool, value)
+		_node.Disabled = value
 	}
 	if value, ok := uc.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)

--- a/ent/user_update.go
+++ b/ent/user_update.go
@@ -84,6 +84,34 @@ func (uu *UserUpdate) SetNillableVerified(b *bool) *UserUpdate {
 	return uu
 }
 
+// SetRole sets the "role" field.
+func (uu *UserUpdate) SetRole(s string) *UserUpdate {
+	uu.mutation.SetRole(s)
+	return uu
+}
+
+// SetNillableRole sets the "role" field if the given value is not nil.
+func (uu *UserUpdate) SetNillableRole(s *string) *UserUpdate {
+	if s != nil {
+		uu.SetRole(*s)
+	}
+	return uu
+}
+
+// SetDisabled sets the "disabled" field.
+func (uu *UserUpdate) SetDisabled(b bool) *UserUpdate {
+	uu.mutation.SetDisabled(b)
+	return uu
+}
+
+// SetNillableDisabled sets the "disabled" field if the given value is not nil.
+func (uu *UserUpdate) SetNillableDisabled(b *bool) *UserUpdate {
+	if b != nil {
+		uu.SetDisabled(*b)
+	}
+	return uu
+}
+
 // AddOwnerIDs adds the "owner" edge to the PasswordToken entity by IDs.
 func (uu *UserUpdate) AddOwnerIDs(ids ...int) *UserUpdate {
 	uu.mutation.AddOwnerIDs(ids...)
@@ -195,6 +223,12 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := uu.mutation.Verified(); ok {
 		_spec.SetField(user.FieldVerified, field.TypeBool, value)
+	}
+	if value, ok := uu.mutation.Role(); ok {
+		_spec.SetField(user.FieldRole, field.TypeString, value)
+	}
+	if value, ok := uu.mutation.Disabled(); ok {
+		_spec.SetField(user.FieldDisabled, field.TypeBool, value)
 	}
 	if uu.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -313,6 +347,34 @@ func (uuo *UserUpdateOne) SetVerified(b bool) *UserUpdateOne {
 func (uuo *UserUpdateOne) SetNillableVerified(b *bool) *UserUpdateOne {
 	if b != nil {
 		uuo.SetVerified(*b)
+	}
+	return uuo
+}
+
+// SetRole sets the "role" field.
+func (uuo *UserUpdateOne) SetRole(s string) *UserUpdateOne {
+	uuo.mutation.SetRole(s)
+	return uuo
+}
+
+// SetNillableRole sets the "role" field if the given value is not nil.
+func (uuo *UserUpdateOne) SetNillableRole(s *string) *UserUpdateOne {
+	if s != nil {
+		uuo.SetRole(*s)
+	}
+	return uuo
+}
+
+// SetDisabled sets the "disabled" field.
+func (uuo *UserUpdateOne) SetDisabled(b bool) *UserUpdateOne {
+	uuo.mutation.SetDisabled(b)
+	return uuo
+}
+
+// SetNillableDisabled sets the "disabled" field if the given value is not nil.
+func (uuo *UserUpdateOne) SetNillableDisabled(b *bool) *UserUpdateOne {
+	if b != nil {
+		uuo.SetDisabled(*b)
 	}
 	return uuo
 }
@@ -458,6 +520,12 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 	}
 	if value, ok := uuo.mutation.Verified(); ok {
 		_spec.SetField(user.FieldVerified, field.TypeBool, value)
+	}
+	if value, ok := uuo.mutation.Role(); ok {
+		_spec.SetField(user.FieldRole, field.TypeString, value)
+	}
+	if value, ok := uuo.mutation.Disabled(); ok {
+		_spec.SetField(user.FieldDisabled, field.TypeBool, value)
 	}
 	if uuo.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/handlers/auth.go
+++ b/pkg/handlers/auth.go
@@ -200,7 +200,8 @@ func (h *Auth) LoginSubmit(ctx echo.Context) error {
 	// Attempt to load the user
 	u, err := h.orm.User.
 		Query().
-		Where(user.Email(strings.ToLower(input.Email))).
+		Where(user.Email(strings.ToLower(input.Email)),
+			user.Disabled(false)).
 		Only(ctx.Request().Context())
 
 	switch err.(type) {

--- a/pkg/handlers/userManagement.go
+++ b/pkg/handlers/userManagement.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"fmt"
+	"github.com/labstack/echo/v4"
+	"github.com/mikestefanello/pagoda/ent"
+	"github.com/mikestefanello/pagoda/ent/user"
+	"github.com/mikestefanello/pagoda/pkg/context"
+	"github.com/mikestefanello/pagoda/pkg/page"
+	"github.com/mikestefanello/pagoda/templates"
+	"net/http"
+
+	"github.com/mikestefanello/pagoda/pkg/middleware"
+	"github.com/mikestefanello/pagoda/pkg/services"
+)
+
+const (
+	routeNameUserDetails = "userDetails"
+	routeNameUpdateUser  = "updateUser"
+)
+
+type (
+	UserManagement struct {
+		mail *services.MailClient
+		orm  *ent.Client
+		*services.TemplateRenderer
+		auth *services.AuthClient
+	}
+
+	UserRequest struct {
+		Users []string `json:"users"`
+	}
+
+	NotAuthenticatedError struct{}
+)
+
+func init() {
+	Register(new(UserManagement))
+}
+
+func (u *UserManagement) Init(c *services.Container) error {
+	u.TemplateRenderer = c.TemplateRenderer
+	u.mail = c.Mail
+	u.orm = c.ORM
+	return nil
+}
+
+func (u *UserManagement) Routes(g *echo.Group) {
+	UMGroup := g.Group("/userManagement", middleware.RequireAuthentication())
+	UMGroup.GET("/userDetails", u.UserDetails).Name = routeNameUserDetails
+	UMGroup.POST("/updateUserState", u.UpdateUserState).Name = routeNameUpdateUser
+}
+
+func (u *UserManagement) UserDetails(ctx echo.Context) error {
+	currentUser := ctx.Get(context.AuthenticatedUserKey).(*ent.User)
+	p := page.New(ctx)
+	p.Layout = templates.LayoutMain
+
+	if currentUser.Role != "admin" {
+		p.Name = templates.PageError
+		p.StatusCode = http.StatusForbidden
+		return u.RenderPage(ctx, p)
+	}
+
+	allUsers, err := u.orm.User.Query().All(ctx.Request().Context())
+	if err != nil {
+		return err
+	}
+
+	p.Name = templates.PageUserManagement
+	p.Title = "User Management"
+	p.Data = allUsers
+
+	return u.RenderPage(ctx, p)
+}
+
+func (u *UserManagement) UpdateUserState(ctx echo.Context) error {
+	usr := ctx.Get(context.AuthenticatedUserKey).(*ent.User)
+	p := page.New(ctx)
+	p.Layout = templates.LayoutMain
+	if usr.Role != "admin" {
+		p.Name = templates.PageError
+		p.StatusCode = http.StatusForbidden
+		return u.RenderPage(ctx, p)
+	}
+
+	state := ctx.Request().Form.Get("state")
+	users := ctx.Request().Form["users"]
+	if len(users) == 0 {
+		p.Name = templates.PageError
+		p.StatusCode = http.StatusBadRequest
+		return u.RenderPage(ctx, p)
+	}
+
+	// Determine new state (true = disable, false = enable)
+	disable := state == "disable"
+	newState := "enable"
+	newClass := "button is-warning is-rounded"
+	buttonText := "Enable"
+
+	if !disable {
+		newState = "disable"
+		buttonText = "Disable"
+		newClass = "button is-danger is-rounded"
+	}
+
+	// Update all users in a single query
+	updatedUserState, err := u.orm.User.Update().
+		Where(user.EmailIn(users...), user.RoleNEQ("admin")).
+		SetDisabled(disable).
+		Save(ctx.Request().Context())
+
+	if err != nil || updatedUserState == 0 {
+		return fail(err, "failed to update user state")
+	}
+
+	// Generate button HTML response
+	buttonHTML := fmt.Sprintf(
+		`<button hx-post="/userManagement/updateUserState" hx-vals='{"state":"%s","users":["%s"]}' hx-target="this" hx-swap="outerHTML" class="%s">%s</button>`,
+		newState, users[0], newClass, buttonText,
+	)
+
+	return ctx.HTML(http.StatusOK, buttonHTML)
+}

--- a/pkg/handlers/userManagement.go
+++ b/pkg/handlers/userManagement.go
@@ -47,7 +47,7 @@ func (u *UserManagement) Init(c *services.Container) error {
 
 func (u *UserManagement) Routes(g *echo.Group) {
 	UMGroup := g.Group("/userManagement", middleware.RequireAuthentication())
-	UMGroup.GET("/userDetails", u.UserDetails).Name = routeNameUserDetails
+	UMGroup.GET("", u.UserDetails).Name = routeNameUserDetails
 	UMGroup.POST("/updateUserState", u.UpdateUserState).Name = routeNameUpdateUser
 }
 

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -107,3 +107,15 @@ func RequireNoAuthentication() echo.MiddlewareFunc {
 		}
 	}
 }
+
+func CheckUserStatus(client *services.AuthClient) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if err := client.CheckUserStatus(c); err != nil {
+				return echo.NewHTTPError(http.StatusUnauthorized)
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/pkg/page/page.go
+++ b/pkg/page/page.go
@@ -67,6 +67,9 @@ type Page struct {
 	// IsAuth stores whether the user is authenticated
 	IsAuth bool
 
+	//IsAdmin stores whether the user is an admin
+	IsAdmin bool
+
 	// AuthUser stores the authenticated user
 	AuthUser *ent.User
 
@@ -143,6 +146,7 @@ func New(ctx echo.Context) Page {
 	if u := ctx.Get(context.AuthenticatedUserKey); u != nil {
 		p.IsAuth = true
 		p.AuthUser = u.(*ent.User)
+		p.IsAdmin = p.AuthUser.Role == "admin"
 	}
 
 	p.HTMX.Request = htmx.GetRequest(ctx)

--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -120,6 +120,15 @@ func (c *AuthClient) CheckPassword(password, hash string) error {
 	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
 }
 
+// CheckUserStatus check if a given user's Status is disabled
+func (c *AuthClient) CheckUserStatus(ctx echo.Context) error {
+	u, _ := c.GetAuthenticatedUser(ctx)
+	if u.Disabled {
+		return errors.New("user Account Disabled")
+	}
+	return nil
+}
+
 // GeneratePasswordResetToken generates a password reset token for a given user.
 // For security purposes, the token itself is not stored in the database but rather
 // a hash of the token, exactly how passwords are handled. This method returns both

--- a/templates/layouts/main.gohtml
+++ b/templates/layouts/main.gohtml
@@ -30,6 +30,9 @@
                             <li>{{link (url "contact") "Contact" .Path}}</li>
                             <li>{{link (url "cache") "Cache" .Path}}</li>
                             <li>{{link (url "task") "Task" .Path}}</li>
+                            {{- if .IsAdmin }}
+                            <li>{{link (url "userDetails") "User Management" .Path}}</li>
+                            {{- end }}
                         </ul>
 
                         <p class="menu-label">Account</p>

--- a/templates/pages/user-management.gohtml
+++ b/templates/pages/user-management.gohtml
@@ -1,0 +1,56 @@
+{{define "content"}}
+    {{template "UserDetail" .}}
+{{end}}
+
+{{define "UserDetail"}}
+    <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
+        <thead>
+        <tr>
+            <th>UserId</th>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Verified</th>
+            <th>Status</th>
+        </tr>
+        </thead>
+        <tfoot>
+        <tr>
+            <th>UserId</th>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Verified</th>
+            <th>Status</th>
+        </tr>
+        </tfoot>
+        <tbody>
+        {{- range .Data}}
+            <tr>
+                <td>{{.ID}}</td>
+                <td>{{.Name}}</td>
+                <td>{{.Email}}</td>
+                <td>{{.Role}}</td>
+                <td>{{.Verified}}</td>
+                <td>
+                    {{ if .Disabled }}
+                        <button hx-post="/userManagement/updateUserState"
+                                hx-vals='{"state":"enable","users": ["{{.Email}}"]}'
+                                hx-target="this"
+                                hx-swap="outerHTML"
+                                class="button is-warning is-rounded">Enable</button>
+
+                    {{else}}
+                        <button hx-post="/userManagement/updateUserState"
+                                hx-vals='{"state":"disable","users": ["{{.Email}}"]}'
+                                hx-target="this"
+                                hx-swap="outerHTML"
+                                class="button is-danger is-rounded">Disable</button>
+                    {{end}}
+                </td>
+            </tr>
+        {{- end}}
+        </tbody>
+    </table>
+            {{template "csrf" .}}
+{{end}}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -32,6 +32,7 @@ const (
 	PageResetPassword  Page = "reset-password"
 	PageSearch         Page = "search"
 	PageTask           Page = "task"
+	PageUserManagement Page = "user-management"
 )
 
 //go:embed *


### PR DESCRIPTION
Hi @mikestefanello,

I’ve been using Pagoda for one of my projects and noticed the absence of a generic user management system for enabling/disabling users and managing access levels. This PR introduces a module to address that.

Routes:
`/userManagement` – Displays the list of users (admin only).
`/updateUserState` – Allows admins to enable/disable users.

This functionality can be expanded further as needed. Let me know your thoughts!

Best,
Ranjith