### PR TITLE
Fix HTTPErrorHandler always returning 200

### DIFF
--- a/pkg/handlers/error.go
+++ b/pkg/handlers/error.go
@@ -32,7 +32,7 @@ func (e *Error) Page(err error, ctx echo.Context) {
 	}
 
 	// Set the status code.
-	ctx.Response().Status = code
+	ctx.Response().WriteHeader(code)
 
 	// Render the error page.
 	if err = pages.Error(ctx, code); err != nil {


### PR DESCRIPTION
While I was experimenting with Pagoda, I noticed that no matter what handler or helper function I used I was always getting a 200 status code, the error template message works correctly and show the appropriate error, just with a 200 status code. This commit fixes the bug.